### PR TITLE
Fix API capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Description
-Ce script permet de récupérer, pour le club de gymnastique artistique féminine de son choix, les résultats des compétitions de la saison 2022 sur le site de la Fédération Française de Gym (https://resultats.ffgym.fr/accueil) via leur api.
+Ce script permet de récupérer, pour le club de gymnastique artistique féminine de son choix, les résultats des compétitions de la saison 2022 sur le site de la Fédération Française de Gym (https://resultats.ffgym.fr/accueil) via leur API.
 Après avoir téléchargé les résultats, un fichier png par compétition est sauvegardé, contenant les graphiques des résultats pour chaque catégorie.
 
 # Utilisation


### PR DESCRIPTION
## Summary
- replace "via leur api" with "via leur API" in README

## Testing
- `python -m py_compile analyse_palmares.py`

------
https://chatgpt.com/codex/tasks/task_e_68651f19809883298077ff0e7e63833f