### PR TITLE
Fix event filtering when club not present

### DIFF
--- a/analyse_palmares.py
+++ b/analyse_palmares.py
@@ -77,6 +77,8 @@ def filter_data_with(d, filter_str):
                     with_gif = True
             if not with_gif:
                 del filtered_dic[ne][nc]
+        if len(filtered_dic[ne]) == 0:
+            del filtered_dic[ne]
 
     return filtered_dic
 


### PR DESCRIPTION
## Summary
- remove events without any categories from `filter_data_with`
- ensure the script won't keep empty events after filtering

## Testing
- `python analyse_palmares.py` *(fails: No module named 'matplotlib')*
- `pip install matplotlib` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68651f22e1b88329acb6955d09fa1fe2