### PR TITLE
Add pytest test for filter logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ On réalise en premier lieu une recherche à partir du nom du club, des IDs de c
 # Exemple de résultat
 ![HERBLAY](https://user-images.githubusercontent.com/46487340/159429159-57b1a003-2f1c-4ae0-b5d6-8a21565f4243.png)
 Les gymnastes du club sont représentées en couleur, et leur note ainsi que leur classement est indiqué dans la légende. Les autres participantes sont représentées en gris.
+
+## Tests
+Les tests unitaires utilisent `pytest`. Pour lancer la suite de tests, installez les dépendances nécessaires puis exécutez la commande `pytest` à la racine du projet.

--- a/analyse_palmares.py
+++ b/analyse_palmares.py
@@ -71,12 +71,11 @@ def filter_data_with(d, filter_str):
 
     for ne, event in d.items():
         for nc, cat in event.items():
-            with_gif = False
-            for (city, _), _ in cat.items():
-                if city == filter_str:
-                    with_gif = True
+            with_gif = any(city == filter_str for (city, _), _ in cat.items())
             if not with_gif:
                 del filtered_dic[ne][nc]
+        if len(filtered_dic[ne]) == 0:
+            del filtered_dic[ne]
 
     return filtered_dic
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,40 @@
+import pytest
+import os
+import sys
+import types
+
+# Create dummy modules to satisfy analyse_palmares imports without requiring
+# the actual heavy dependencies.
+matplotlib_dummy = types.ModuleType("matplotlib")
+pyplot_dummy = types.ModuleType("pyplot")
+setattr(matplotlib_dummy, "pyplot", pyplot_dummy)
+sys.modules.setdefault("matplotlib", matplotlib_dummy)
+sys.modules.setdefault("matplotlib.pyplot", pyplot_dummy)
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+pd_dummy = types.ModuleType("pandas")
+pd_dummy.set_option = lambda *a, **k: None
+sys.modules.setdefault("pandas", pd_dummy)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from analyse_palmares import filter_data_with
+
+
+def test_filter_data_removes_unmatched_categories_and_events():
+    data = {
+        ("Event1", "date"): {
+            ("Cat1", "EQU"): {("GIF SUR YVETTE", "Team1"): {"classement": 1, "gyms": {}}},
+            ("Cat2", "EQU"): {("OTHER", "TeamB"): {"classement": 1, "gyms": {}}},
+        },
+        ("Event2", "date"): {
+            ("Cat3", "EQU"): {("OTHER", "TeamC"): {"classement": 1, "gyms": {}}}
+        },
+    }
+
+    filtered = filter_data_with(data, "GIF SUR YVETTE")
+
+    assert ("Event1", "date") in filtered
+    assert ("Cat1", "EQU") in filtered[("Event1", "date")]
+    assert ("Cat2", "EQU") not in filtered[("Event1", "date")]
+
+    assert ("Event2", "date") not in filtered


### PR DESCRIPTION
## Summary
- improve `filter_data_with` to drop empty events
- document pytest usage
- add unit test for filtering logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651f28107c8329a3c8a3f353bdf427